### PR TITLE
[NB-116] 요청을 보낸 사용자의 정보를 가져오는 기능 구현

### DIFF
--- a/src/main/java/com/soyeon/nubim/domain/user/UserRepository.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserRepository.java
@@ -3,10 +3,14 @@ package com.soyeon.nubim.domain.user;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
+
+	@Query("SELECT u.userId FROM User u WHERE u.email = :email")
+	Optional<Long> findUserIdByEmail(String email);
 }

--- a/src/main/java/com/soyeon/nubim/domain/user/UserService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserService.java
@@ -3,13 +3,14 @@ package com.soyeon.nubim.domain.user;
 import java.util.Optional;
 
 import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import com.soyeon.nubim.security.refreshtoken.RefreshTokenService;
-import lombok.RequiredArgsConstructor;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -52,5 +53,23 @@ public class UserService {
 	public User findUserByIdOrThrow(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new UserNotFoundException(userId));
+	}
+
+	public String getCurrentUserEmail() {
+		return SecurityContextHolder.getContext().getAuthentication().getName();
+	}
+
+	public User getCurrentUser() {
+		String currentUserEmail = getCurrentUserEmail();
+
+		return userRepository.findByEmail(currentUserEmail)
+			.orElseThrow(() -> new EntityNotFoundException("User with email " + currentUserEmail + " not found"));
+	}
+
+	public Long getCurrentUserId() {
+		String currentUserEmail = getCurrentUserEmail();
+
+		return userRepository.findUserIdByEmail(currentUserEmail)
+			.orElseThrow(() -> new EntityNotFoundException("User with email " + currentUserEmail + " not found"));
 	}
 }


### PR DESCRIPTION
## 개요
NB-116
- UserService에 3가지 메소드 추가
1. getCurrentUserEmail()
   - SecurityContextHolder에서 요청을 보낸 사용자의 email을 반환한다.

2. getCurrentUser()
   - getCurrentUserEmail에서 가져온 email을 통해 요청을 보낸 User를 검색해서 반환한다.

3. getCurrentUserId()
   - getCurrentUserEmail에서 가져온 email을 통해 요청을 보낸 userId를 검색해서 반환한다.
   - User가 아닌 userId만을 검색하기 위해 UserRepository.findUserIdByEmail() 메소드 추가

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
