### PR TITLE
S3 Presigned URL 생성 시 컨텐츠 타입 검증 추가

### DIFF
--- a/src/main/java/com/soyeon/nubim/domain/album/AlbumPhotoUploadUrlService.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/AlbumPhotoUploadUrlService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.soyeon.nubim.common.util.aws.S3PresignedUrlGenerator;
+import com.soyeon.nubim.domain.album.exception.InvalidContentTypeException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,13 +13,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AlbumPhotoUploadUrlService {
 
+	public static final String MIME_TYPE_IMAGE = "image";
 	private final S3PresignedUrlGenerator s3PresignedUrlGenerator;
 
 	public List<String> generatePhotoUploadUrlsWithRandomPath(List<String> contentTypes) {
+		validateContentTypes(contentTypes);
 		return s3PresignedUrlGenerator.generatePresignedUrls(contentTypes);
 	}
 
 	public List<String> generatePhotoUploadUrlsWithCustomPath(List<String> contentTypes, String uploadPath) {
+		validateContentTypes(contentTypes);
 		return s3PresignedUrlGenerator.generatePresignedUrls(contentTypes, uploadPath);
+	}
+
+	private void validateContentTypes(List<String> contentTypes) {
+		for (String contentType : contentTypes) {
+			if (!contentType.startsWith(MIME_TYPE_IMAGE)) {
+				throw new InvalidContentTypeException("Invalid content type: " + contentType);
+			}
+		}
 	}
 }

--- a/src/main/java/com/soyeon/nubim/domain/album/exception/InvalidContentTypeException.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/exception/InvalidContentTypeException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.album.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class InvalidContentTypeException extends ResponseStatusException {
+	public InvalidContentTypeException(String message) {
+		super(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Invalid content type: " + message);
+	}
+}


### PR DESCRIPTION
## 개요
- Presigned URL 생성 시 이미지가 아닌 컨텐츠 타입에 대한 예외 발생
- Presigned URL 을 통해 이미지 파일만 업로드할 수 있도록 함
## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)