### PR TITLE
[NB-222, NB-223] Album 엔티티 path 필드 추가 및 로직 수정

### DIFF
--- a/src/main/java/com/soyeon/nubim/domain/album/Album.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/Album.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.Type;
 
 import com.soyeon.nubim.common.BaseEntity;
 import com.soyeon.nubim.domain.album.exception.AlbumAlreadyLinkedToPostException;
-import com.soyeon.nubim.domain.post.Post;
 import com.soyeon.nubim.domain.user.User;
 import com.vladmihalcea.hibernate.type.json.JsonType;
 
@@ -62,6 +61,11 @@ public class Album extends BaseEntity {
 	@Builder.Default
 	@OneToMany(mappedBy = "album", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<Location> locations = new ArrayList<>();
+
+	@Builder.Default
+	@Type(JsonType.class)
+	@Column(columnDefinition = "jsonb")
+	private List<List<Double>> path = new ArrayList<>();
 
 	public void bindLocations() {
 		for (Location location : locations) {

--- a/src/main/java/com/soyeon/nubim/domain/album/AlbumService.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/AlbumService.java
@@ -44,6 +44,7 @@ public class AlbumService {
 	@Transactional
 	public AlbumCreateResponseDto createAlbum(AlbumCreateRequestDto albumCreateRequestDto) {
 		User currentUser = userService.getCurrentUser();
+		albumValidator.validateAlbumPathCoordinates(albumCreateRequestDto);
 
 		Album album = albumMapper.toEntity(albumCreateRequestDto, currentUser);
 
@@ -91,6 +92,7 @@ public class AlbumService {
 	@Transactional
 	public AlbumReadResponseDto updateAlbum(Long albumId, AlbumUpdateRequestDto albumUpdateRequestDto) {
 		albumValidator.validateAlbumOwner(albumId, userService.getCurrentUserId());
+		albumValidator.validateAlbumPathCoordinates(albumUpdateRequestDto);
 		Album album = albumRepository.findByIdWithLocations(albumId)
 			.orElseThrow(() -> new AlbumNotFoundException(albumId));
 
@@ -113,6 +115,8 @@ public class AlbumService {
 		List<Location> newLocations = locationMapper.toEntityListFromUpdateDto(newLocationDtos);
 		album.setLocations(newLocations);
 		album.bindLocations();
+
+		album.setPath(albumUpdateRequestDto.getPath());
 
 		Album updatedAlbum = albumRepository.save(album);
 		return albumMapper.toAlbumReadResponseDto(updatedAlbum);

--- a/src/main/java/com/soyeon/nubim/domain/album/AlbumValidator.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/AlbumValidator.java
@@ -1,8 +1,12 @@
 package com.soyeon.nubim.domain.album;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import com.soyeon.nubim.domain.album.dto.AlbumRequestDto;
 import com.soyeon.nubim.domain.album.exception.AlbumNotFoundException;
+import com.soyeon.nubim.domain.album.exception.InvalidCoordinateException;
 import com.soyeon.nubim.domain.album.exception.UnauthorizedAlbumAccessException;
 
 import lombok.RequiredArgsConstructor;
@@ -12,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class AlbumValidator {
 
 	private final AlbumRepository albumRepository;
+	private static final int COORDINATE_DIMENSION = 2;
 
 	public void validateAlbumOwner(Long albumId, Long userId) {
 		Long albumOwnerId = albumRepository.findAlbumOwnerIdByAlbumId(albumId)
@@ -19,6 +24,16 @@ public class AlbumValidator {
 
 		if (!albumOwnerId.equals(userId)) {
 			throw new UnauthorizedAlbumAccessException(albumOwnerId);
+		}
+	}
+
+	public void validateAlbumPathCoordinates(AlbumRequestDto albumRequestDto) {
+		List<List<Double>> path = albumRequestDto.getPath();
+		for (List<Double> coordinate : path) {
+			int dimension = coordinate.size();
+			if (dimension != COORDINATE_DIMENSION) {
+				throw new InvalidCoordinateException(dimension);
+			}
 		}
 	}
 }

--- a/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumCreateRequestDto.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumCreateRequestDto.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-public class AlbumCreateRequestDto {
+public class AlbumCreateRequestDto implements AlbumRequestDto {
 	private String description;
 	private Map<Integer, String> photoUrls;
 	private List<LocationCreateRequestDto> locations;

--- a/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumCreateRequestDto.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumCreateRequestDto.java
@@ -14,4 +14,5 @@ public class AlbumCreateRequestDto {
 	private String description;
 	private Map<Integer, String> photoUrls;
 	private List<LocationCreateRequestDto> locations;
+	private List<List<Double>> path;
 }

--- a/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumCreateResponseDto.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumCreateResponseDto.java
@@ -17,6 +17,7 @@ public class AlbumCreateResponseDto implements AlbumResponseDto {
 	private String description;
 	private Map<Integer, String> photoUrls;
 	private List<LocationCreateResponseDto> locations;
+	private List<List<Double>> path;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumReadResponseDto.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumReadResponseDto.java
@@ -17,6 +17,7 @@ public class AlbumReadResponseDto implements AlbumResponseDto {
 	private String description;
 	private Map<Integer, String> photoUrls;
 	private List<LocationReadResponseDto> locations;
+	private List<List<Double>> path;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumRequestDto.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumRequestDto.java
@@ -1,0 +1,7 @@
+package com.soyeon.nubim.domain.album.dto;
+
+import java.util.List;
+
+public interface AlbumRequestDto {
+	List<List<Double>> getPath();
+}

--- a/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumUpdateRequestDto.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumUpdateRequestDto.java
@@ -12,4 +12,5 @@ public class AlbumUpdateRequestDto {
 	private String description;
 	private Map<Integer, String> photoUrls;
 	private List<LocationUpdateRequestDto> locations;
+	private List<List<Double>> path;
 }

--- a/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumUpdateRequestDto.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/dto/AlbumUpdateRequestDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class AlbumUpdateRequestDto {
+public class AlbumUpdateRequestDto implements AlbumRequestDto {
 	private String description;
 	private Map<Integer, String> photoUrls;
 	private List<LocationUpdateRequestDto> locations;

--- a/src/main/java/com/soyeon/nubim/domain/album/exception/InvalidCoordinateException.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/exception/InvalidCoordinateException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.album.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class InvalidCoordinateException extends ResponseStatusException {
+	public InvalidCoordinateException(int actualDimension) {
+		super(HttpStatus.BAD_REQUEST, "Invalid coordinate: Expected 2 values, but got " + actualDimension);
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/album/mapper/AlbumMapper.java
+++ b/src/main/java/com/soyeon/nubim/domain/album/mapper/AlbumMapper.java
@@ -43,6 +43,7 @@ public class AlbumMapper {
 			.description(albumCreateRequestDto.getDescription())
 			.photoUrls(photoUrls)
 			.locations(locations)
+			.path(albumCreateRequestDto.getPath())
 			.build();
 
 		album.bindLocations();
@@ -63,6 +64,7 @@ public class AlbumMapper {
 			.description(album.getDescription())
 			.photoUrls(cdnPhotoUrls)
 			.locations(locationCreateResponseDtos)
+			.path(album.getPath())
 			.createdAt(album.getCreatedAt())
 			.updatedAt(album.getUpdatedAt())
 			.build();
@@ -81,6 +83,7 @@ public class AlbumMapper {
 			.description(album.getDescription())
 			.photoUrls(cdnPhotoUrls)
 			.locations(locationReadResponseDtos)
+			.path(album.getPath())
 			.createdAt(album.getCreatedAt())
 			.updatedAt(album.getUpdatedAt())
 			.build();

--- a/src/test/java/com/soyeon/nubim/domain/album/AlbumControllerV1Test.java
+++ b/src/test/java/com/soyeon/nubim/domain/album/AlbumControllerV1Test.java
@@ -141,10 +141,24 @@ class AlbumControllerV1Test {
 				.build()
 		);
 
+		List<List<Double>> path = List.of(
+			List.of(0.0, 0.0),
+			List.of(1.0, 1.0),
+			List.of(2.0, 2.0),
+			List.of(3.0, 3.0),
+			List.of(4.0, 4.0),
+			List.of(5.0, 5.0),
+			List.of(6.0, 6.0),
+			List.of(7.0, 7.0),
+			List.of(8.0, 8.0),
+			List.of(9.0, 9.0)
+		);
+
 		createRequestDto = AlbumCreateRequestDto.builder()
 			.description(description)
 			.photoUrls(photoUrls)
 			.locations(locationsRequest)
+			.path(path)
 			.build();
 
 		createResponseDto = AlbumCreateResponseDto.builder()
@@ -153,6 +167,7 @@ class AlbumControllerV1Test {
 			.description(description)
 			.photoUrls(photoUrls)
 			.locations(locationsResponse)
+			.path(path)
 			.build();
 
 		readResponseDto = AlbumReadResponseDto.builder()
@@ -170,6 +185,7 @@ class AlbumControllerV1Test {
 					.placeName("서울")
 					.build()
 			))
+			.path(path)
 			.build();
 
 		updateRequestDto = AlbumUpdateRequestDto.builder()
@@ -183,6 +199,7 @@ class AlbumControllerV1Test {
 					.placeName("경기도")
 					.build())
 			)
+			.path(path)
 			.build();
 	}
 
@@ -200,6 +217,7 @@ class AlbumControllerV1Test {
 			.andExpect(jsonPath("$.description").value(createResponseDto.getDescription()))
 			.andExpect(jsonPath("$.photoUrls").isNotEmpty())
 			.andExpect(jsonPath("$.locations").isNotEmpty())
+			.andExpect(jsonPath("$.path").isNotEmpty())
 			.andReturn();
 
 		String content = result.getResponse().getContentAsString();
@@ -249,7 +267,8 @@ class AlbumControllerV1Test {
 			.andExpect(jsonPath("$.photoUrls").isNotEmpty())
 			.andExpect(jsonPath("$.locations").isNotEmpty())
 			.andExpect(
-				jsonPath("$.locations[0].placeName").value(readResponseDto.getLocations().get(0).getPlaceName()));
+				jsonPath("$.locations[0].placeName").value(readResponseDto.getLocations().get(0).getPlaceName()))
+			.andExpect(jsonPath("$.path").isNotEmpty());
 
 		verify(albumService).findByIdWithLocations(albumId);
 	}
@@ -301,6 +320,14 @@ class AlbumControllerV1Test {
 			assertEquals(expectedLocation.getVisitedAt(), actualLocation.getVisitedAt());
 			assertEquals(expectedLocation.getPlaceName(), actualLocation.getPlaceName());
 		}
+
+		assertEquals(readResponseDto.getPath().size(), actualAlbums.get(0).getPath().size());
+		for (int i = 0; i < readResponseDto.getPath().size(); i++) {
+			List<Double> expectedPath = readResponseDto.getPath().get(i);
+			List<Double> actualPath = actualAlbums.get(0).getPath().get(i);
+			assertEquals(expectedPath.get(0), actualPath.get(0));
+			assertEquals(expectedPath.get(1), actualPath.get(1));
+		}
 	}
 
 	@Test
@@ -341,6 +368,7 @@ class AlbumControllerV1Test {
 			.description(updateRequestDto.getDescription())
 			.photoUrls(updateRequestDto.getPhotoUrls())
 			.locations(locationReadList)
+			.path(readResponseDto.getPath())
 			.build();
 
 		when(albumService.updateAlbum(any(Long.class), any(AlbumUpdateRequestDto.class))).thenReturn(updateResponseDto);
@@ -355,6 +383,7 @@ class AlbumControllerV1Test {
 			.andExpect(jsonPath("$.description").value(updateRequestDto.getDescription()))
 			.andExpect(jsonPath("$.photoUrls").isNotEmpty())
 			.andExpect(jsonPath("$.locations").isNotEmpty())
+			.andExpect(jsonPath("$.path").isNotEmpty())
 			.andReturn();
 
 		String content = result.getResponse().getContentAsString();

--- a/src/test/java/com/soyeon/nubim/domain/album/AlbumIntegrationTest.java
+++ b/src/test/java/com/soyeon/nubim/domain/album/AlbumIntegrationTest.java
@@ -104,10 +104,22 @@ public class AlbumIntegrationTest {
 			.placeName("제주")
 			.build();
 
+		List<List<Double>> path = List.of(List.of(0.0, 0.0),
+			List.of(1.0, 1.0),
+			List.of(2.0, 2.0),
+			List.of(3.0, 3.0),
+			List.of(4.0, 4.0),
+			List.of(5.0, 5.0),
+			List.of(6.0, 6.0),
+			List.of(7.0, 7.0),
+			List.of(8.0, 8.0),
+			List.of(9.0, 9.0));
+
 		createRequestDto = AlbumCreateRequestDto.builder()
 			.description("create test album")
 			.photoUrls(Map.of(1, s3BucketUrlPrefix + "/test01.jpg", 2, s3BucketUrlPrefix + "/test02.jpg"))
 			.locations(List.of(location1, location2))
+			.path(path)
 			.build();
 
 		LocationUpdateRequestDto newLocation = LocationUpdateRequestDto.builder()
@@ -117,10 +129,13 @@ public class AlbumIntegrationTest {
 			.placeName("new place")
 			.build();
 
+		List<List<Double>> newPath = List.of(List.of(0.0, 0.0));
+
 		updateRequestDto = AlbumUpdateRequestDto.builder()
 			.description("updated description")
 			.photoUrls(Map.of(1, s3BucketUrlPrefix + "/updated01.jpg", 2, cdnUrl + "/updated02.jpg"))
 			.locations(List.of(newLocation))
+			.path(newPath)
 			.build();
 	}
 
@@ -136,7 +151,8 @@ public class AlbumIntegrationTest {
 			.andExpect(jsonPath("$.description").value("create test album"))
 			.andExpect(jsonPath("$.photoUrls").exists())
 			.andExpect(jsonPath("$.locations").exists())
-			.andExpect(jsonPath("$.userId").value(user.getUserId()));
+			.andExpect(jsonPath("$.userId").value(user.getUserId()))
+			.andExpect(jsonPath("$.path").exists());
 	}
 
 	@Test
@@ -161,7 +177,8 @@ public class AlbumIntegrationTest {
 			.andExpect(jsonPath("$.photoUrls").exists())
 			.andExpect(jsonPath("$.photoUrls.*", everyItem(startsWith(cdnUrl))))
 			.andExpect(jsonPath("$.locations").exists())
-			.andExpect(jsonPath("$.userId").value(user.getUserId()));
+			.andExpect(jsonPath("$.userId").value(user.getUserId()))
+			.andExpect(jsonPath("$.path").exists());
 	}
 
 	@Test
@@ -185,7 +202,8 @@ public class AlbumIntegrationTest {
 			.andExpect(jsonPath("$").isArray())
 			.andExpect(jsonPath("$", hasSize(2)))
 			.andExpect(jsonPath("$[0].description").value("create test album"))
-			.andExpect(jsonPath("$[1].description").value("create test album"));
+			.andExpect(jsonPath("$[1].description").value("create test album"))
+			.andExpect(jsonPath("$[0].path").value(hasSize(10)));
 	}
 
 	@Test
@@ -202,7 +220,8 @@ public class AlbumIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$").isArray())
 			.andExpect(jsonPath("$", hasSize(1)))
-			.andExpect(jsonPath("$[0].description").value("create test album"));
+			.andExpect(jsonPath("$[0].description").value("create test album"))
+			.andExpect(jsonPath("$[0].path").value(hasSize(10)));
 	}
 
 	@Test
@@ -228,7 +247,8 @@ public class AlbumIntegrationTest {
 			.andExpect(jsonPath("$.description").value("updated description"))
 			.andExpect(jsonPath("$.photoUrls").exists())
 			.andExpect(jsonPath("$.photoUrls.*", everyItem(startsWith(cdnUrl))))
-			.andExpect(jsonPath("$.locations").value(hasSize(1)));
+			.andExpect(jsonPath("$.locations").value(hasSize(1)))
+			.andExpect(jsonPath("$.path").value(hasSize(1)));
 	}
 
 	@Test

--- a/src/test/java/com/soyeon/nubim/domain/album/AlbumRepositoryTest.java
+++ b/src/test/java/com/soyeon/nubim/domain/album/AlbumRepositoryTest.java
@@ -61,8 +61,20 @@ class AlbumRepositoryTest {
 			.visitedAt(LocalDateTime.now())
 			.build();
 
+		List<List<Double>> path = List.of(List.of(0.0, 0.0),
+			List.of(1.0, 1.0),
+			List.of(2.0, 2.0),
+			List.of(3.0, 3.0),
+			List.of(4.0, 4.0),
+			List.of(5.0, 5.0),
+			List.of(6.0, 6.0),
+			List.of(7.0, 7.0),
+			List.of(8.0, 8.0),
+			List.of(9.0, 9.0));
+
 		album.setLocations(List.of(location1, location2));
 		album.bindLocations();
+		album.setPath(path);
 
 		album.setUser(user);
 
@@ -132,7 +144,7 @@ class AlbumRepositoryTest {
 
 		assertThrows(AlbumNotFoundException.class, () ->
 			albumRepository.findByIdWithLocations(album.getAlbumId()).orElseThrow(
-				()-> new AlbumNotFoundException(album.getAlbumId())
+				() -> new AlbumNotFoundException(album.getAlbumId())
 			));
 	}
 }


### PR DESCRIPTION
## 개요
NB-222
- Album 엔티티에 path(이동 경로) 필드 추가
- 관련 Dto 수정

NB-223
- Album 엔티티에 path 필드 추가에 따른 관련 로직 수정
- AlbumRequestDto 인터페이스 도입
- 테스트 코드 수정

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
