### PR TITLE
[NB-233] 토큰 처리 로직 개선 및 애플 로그인 idToken 형식 수정

### DIFF
--- a/src/main/java/com/soyeon/nubim/security/oauth/AppleOAuthLoginService.java
+++ b/src/main/java/com/soyeon/nubim/security/oauth/AppleOAuthLoginService.java
@@ -30,6 +30,7 @@ public class AppleOAuthLoginService {
 	private final OAuthLoginCommons oAuthLoginCommons;
 
 	public ResponseEntity<JwtTokenResponseDto> authenticateWithAppleToken(String idToken) {
+		idToken = oAuthLoginCommons.parseBearerToken(idToken);
 		appleIdTokenValidator.validateAppleIdToken(idToken);
 		User user = fetchAppleUserInfo(idToken);
 

--- a/src/main/java/com/soyeon/nubim/security/oauth/GoogleOAuthLoginService.java
+++ b/src/main/java/com/soyeon/nubim/security/oauth/GoogleOAuthLoginService.java
@@ -12,6 +12,7 @@ import com.soyeon.nubim.domain.user.User;
 import com.soyeon.nubim.domain.user.UserService;
 import com.soyeon.nubim.domain.user.exception.UserNotFoundException;
 import com.soyeon.nubim.security.jwt.dto.JwtTokenResponseDto;
+import com.soyeon.nubim.security.oauth.exception.InvalidTokenException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -41,16 +42,13 @@ public class GoogleOAuthLoginService {
 
 	private static void validateOAuthAccessToken(String oauthAccessToken) {
 		if (oauthAccessToken == null) {
-			throw new IllegalArgumentException("OAuth Access Token cannot be null");
-		}
-		if (!oauthAccessToken.startsWith("Bearer ")) {
-			throw new IllegalArgumentException("OAuth Access Token must start with 'Bearer '");
+			throw new InvalidTokenException("OAuth Access Token cannot be null");
 		}
 	}
 
 	private GoogleUserInfo fetchGoogleUserInfo(String oauthAccessToken) {
 		HttpHeaders headers = new HttpHeaders();
-		headers.setBearerAuth(parseBearerToken(oauthAccessToken));
+		headers.setBearerAuth(oAuthLoginCommons.parseBearerToken(oauthAccessToken));
 		HttpEntity<String> entity = new HttpEntity<>("parameters", headers);
 
 		return restTemplate.exchange(
@@ -59,10 +57,6 @@ public class GoogleOAuthLoginService {
 			entity,
 			GoogleUserInfo.class
 		).getBody();
-	}
-
-	private static String parseBearerToken(String accessToken) {
-		return accessToken.substring(7);
 	}
 
 	private User upsertUserFromGoogleUserInfo(GoogleUserInfo userInfo) {

--- a/src/main/java/com/soyeon/nubim/security/oauth/OAuthLoginCommons.java
+++ b/src/main/java/com/soyeon/nubim/security/oauth/OAuthLoginCommons.java
@@ -7,6 +7,7 @@ import com.soyeon.nubim.domain.user.User;
 import com.soyeon.nubim.domain.user.exception.EmailAlreadyExistsException;
 import com.soyeon.nubim.security.jwt.JwtTokenProvider;
 import com.soyeon.nubim.security.jwt.dto.JwtTokenResponseDto;
+import com.soyeon.nubim.security.oauth.exception.InvalidTokenException;
 import com.soyeon.nubim.security.refreshtoken.RefreshTokenService;
 
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,13 @@ public class OAuthLoginCommons {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RefreshTokenService refreshTokenService;
+
+	protected String parseBearerToken(String token) {
+		if (!token.startsWith("Bearer ")) {
+			throw new InvalidTokenException("Token must start with 'Bearer '");
+		}
+		return token.substring(7);
+	}
 
 	protected JwtTokenResponseDto generateTokenResponse(User user) {
 		String userId = user.getUserId().toString();
@@ -30,8 +38,8 @@ public class OAuthLoginCommons {
 		return new JwtTokenResponseDto(accessToken, refreshToken);
 	}
 
-	protected void validateUserProvider(User user, Provider provider){
-		if( !user.getProvider().equals(provider)) {
+	protected void validateUserProvider(User user, Provider provider) {
+		if (!user.getProvider().equals(provider)) {
 			throw new EmailAlreadyExistsException(user.getEmail());
 		}
 	}

--- a/src/main/java/com/soyeon/nubim/security/oauth/exception/InvalidTokenException.java
+++ b/src/main/java/com/soyeon/nubim/security/oauth/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.security.oauth.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class InvalidTokenException extends ResponseStatusException {
+	public InvalidTokenException(String message) {
+		super(HttpStatus.BAD_REQUEST, "Invalid token : " + message);
+	}
+}


### PR DESCRIPTION
## 개요
NB-233
- 토큰에 "Bearer " 접두어가 붙었는지 검증하는 로직 OAuthLoginCommons 로 이동
- InvalidTokenException 커스텀 예외 추가
- 애플 로그인 시 "Bearer " 접두어가 붙어야 하도록 로직 수정

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
