### PR TITLE
[NB-243, NB-244] 로그아웃, 회원탈퇴 파라미터 수정 및 refresh token 삭제 로직 수정

### DIFF
--- a/src/main/java/com/soyeon/nubim/domain/user/UserControllerV1.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserControllerV1.java
@@ -18,7 +18,6 @@ import com.soyeon.nubim.domain.user.dto.ProfileUpdateRequest;
 import com.soyeon.nubim.domain.user.dto.ProfileUpdateResponse;
 import com.soyeon.nubim.domain.user.dto.UserProfileResponseDto;
 import com.soyeon.nubim.security.jwt.dto.JwtTokenResponseDto;
-import com.soyeon.nubim.security.jwt.dto.TokenDeleteRequestDto;
 import com.soyeon.nubim.security.oauth.AppleOAuthLoginService;
 import com.soyeon.nubim.security.oauth.GoogleOAuthLoginService;
 
@@ -55,20 +54,15 @@ public class UserControllerV1 {
 	}
 
 	@PostMapping("/logout")
-	public ResponseEntity<?> logout(
-		@RequestHeader("Authorization") String accessToken, @RequestBody TokenDeleteRequestDto tokenDeleteRequestDto
-	) {
-		Map<String, String> logoutResult = userService.logout(accessToken, tokenDeleteRequestDto.getRefreshToken());
+	public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken) {
+		Map<String, String> logoutResult = userService.logout(accessToken);
 
 		return ResponseEntity.ok().body(logoutResult);
 	}
 
 	@DeleteMapping("/account")
-	public ResponseEntity<?> deleteAccount(
-		@RequestHeader("Authorization") String accessToken, @RequestBody TokenDeleteRequestDto tokenDeleteRequestDto
-	) {
-		Map<String, String> deleteAccountResult
-			= userService.deleteAccount(accessToken, tokenDeleteRequestDto.getRefreshToken());
+	public ResponseEntity<?> deleteAccount(@RequestHeader("Authorization") String accessToken) {
+		Map<String, String> deleteAccountResult = userService.deleteAccount(accessToken);
 
 		return ResponseEntity.ok().body(deleteAccountResult);
 	}

--- a/src/main/java/com/soyeon/nubim/domain/user/UserService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserService.java
@@ -71,8 +71,9 @@ public class UserService {
 	}
 
 	@Transactional
-	public Map<String, String> logout(String accessToken, String refreshToken) {
-		refreshTokenService.deleteRefreshToken(refreshToken);
+	public Map<String, String> logout(String accessToken) {
+		String currentUserEmail = loggedInUserService.getCurrentUserEmail();
+		refreshTokenService.deleteRefreshToken(currentUserEmail);
 		accessTokenBlacklistService.addToBlacklist(accessToken);
 
 		return Map.of("status", "success",
@@ -80,7 +81,7 @@ public class UserService {
 	}
 
 	@Transactional
-	public Map<String, String> deleteAccount(String accessToken, String refreshToken) {
+	public Map<String, String> deleteAccount(String accessToken) {
 		Long currentUserId = loggedInUserService.getCurrentUserId();
 		validateUserExists(currentUserId);
 
@@ -93,7 +94,8 @@ public class UserService {
 		userFollowRepository.deleteFollowerByUserId(currentUserId);
 		userFollowRepository.deleteFolloweeByUserId(currentUserId);
 
-		refreshTokenService.deleteRefreshToken(refreshToken);
+		String currentUserEmail = loggedInUserService.getCurrentUserEmail();
+		refreshTokenService.deleteRefreshToken(currentUserEmail);
 		accessTokenBlacklistService.addToBlacklist(accessToken);
 
 		return Map.of("status", "success",

--- a/src/main/java/com/soyeon/nubim/security/jwt/dto/TokenDeleteRequestDto.java
+++ b/src/main/java/com/soyeon/nubim/security/jwt/dto/TokenDeleteRequestDto.java
@@ -1,8 +1,0 @@
-package com.soyeon.nubim.security.jwt.dto;
-
-import lombok.Getter;
-
-@Getter
-public class TokenDeleteRequestDto {
-	String refreshToken;
-}

--- a/src/main/java/com/soyeon/nubim/security/refreshtoken/RefreshTokenRepository.java
+++ b/src/main/java/com/soyeon/nubim/security/refreshtoken/RefreshTokenRepository.java
@@ -3,6 +3,8 @@ package com.soyeon.nubim.security.refreshtoken;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -10,7 +12,9 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
 	Optional<RefreshToken> findByEmail(String email);
 
-	Optional<RefreshToken> deleteByToken(String token);
+	@Modifying
+	@Query("DELETE FROM RefreshToken rt WHERE rt.email = :email")
+	int deleteByEmail(String email);
 
 	boolean existsByToken(String token);
 

--- a/src/main/java/com/soyeon/nubim/security/refreshtoken/exception/MultipleRefreshTokensDeletedException.java
+++ b/src/main/java/com/soyeon/nubim/security/refreshtoken/exception/MultipleRefreshTokensDeletedException.java
@@ -1,0 +1,11 @@
+package com.soyeon.nubim.security.refreshtoken.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class MultipleRefreshTokensDeletedException extends ResponseStatusException {
+	public MultipleRefreshTokensDeletedException(int count, String email) {
+		super(HttpStatus.INTERNAL_SERVER_ERROR,
+			String.format("Multiple Refresh Tokens (%d) were deleted for email: %s", count, email));
+	}
+}

--- a/src/main/java/com/soyeon/nubim/security/refreshtoken/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/soyeon/nubim/security/refreshtoken/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.security.refreshtoken.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class RefreshTokenNotFoundException extends ResponseStatusException {
+	public RefreshTokenNotFoundException(String email) {
+		super(HttpStatus.NOT_FOUND, "Refresh Token not found: " + email);
+	}
+}

--- a/src/test/java/com/soyeon/nubim/domain/user/DeleteAccountTest.java
+++ b/src/test/java/com/soyeon/nubim/domain/user/DeleteAccountTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -130,12 +129,9 @@ public class DeleteAccountTest {
 	}
 
 	private void performAccountDeletion() throws Exception {
-		String refreshTokenJson = "{\"refreshToken\": \"" + refreshToken + "\"}";
 
 		mockMvc.perform(delete("/v1/users/account")
-				.header("Authorization", "Bearer " + accessToken)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(refreshTokenJson))
+				.header("Authorization", "Bearer " + accessToken))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.status").value("success"))
 			.andExpect(jsonPath("$.message").value("your account deleted"));
@@ -277,13 +273,8 @@ public class DeleteAccountTest {
 		// 먼저 계정 삭제
 		performAccountDeletion();
 
-		// 다시 삭제 시도
-		String refreshTokenJson = "{\"refreshToken\": \"" + refreshToken + "\"}";
-
 		mockMvc.perform(delete("/v1/users/account")
 				.header("Authorization", "Bearer " + accessToken)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(refreshTokenJson)
 			)
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.message").value("Access denied"));
@@ -297,14 +288,9 @@ public class DeleteAccountTest {
 		String userEmail = "nonexistent@email.com";
 		String role = "USER";
 		String nonExistUserAccessToken = jwtTokenProvider.generateAccessToken(userId, userEmail, role);
-		String nonExistUserRefreshToken = jwtTokenProvider.generateRefreshToken(userId, userEmail, role);
-
-		String refreshTokenJson = "{\"refreshToken\": \"" + nonExistUserRefreshToken + "\"}";
 
 		mockMvc.perform(delete("/v1/users/account")
 				.header("Authorization", "Bearer " + nonExistUserAccessToken)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(refreshTokenJson)
 			)
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.message").value("User not found with id " + userId));


### PR DESCRIPTION
[이슈 번호] 제목
## 개요
NB-243
- deleteByToken 메소드를 deleteByEmail로 변경
- 반환 타입을 Optional<RefreshToken>에서 int로 변경

NB-244
- 로그아웃, 회원탈퇴 엔드포인트에서 파라미터 제거
- 관련 로직 수정
- 테스트 코드 수정

## PR 유형
어떤 변경 사항이 있나요?
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
