### PR TITLE
[NB-145] access token 재발급 로직 개선

### DIFF
--- a/src/main/java/com/soyeon/nubim/common/enums/TokenValidationResult.java
+++ b/src/main/java/com/soyeon/nubim/common/enums/TokenValidationResult.java
@@ -1,0 +1,7 @@
+package com.soyeon.nubim.common.enums;
+
+public enum TokenValidationResult {
+	VALID,
+	INVALID,
+	EXPIRED
+}

--- a/src/main/java/com/soyeon/nubim/config/TransactionConfig.java
+++ b/src/main/java/com/soyeon/nubim/config/TransactionConfig.java
@@ -1,0 +1,18 @@
+package com.soyeon.nubim.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+public class TransactionConfig {
+
+	@Bean
+	public TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+		TransactionTemplate template = new TransactionTemplate(transactionManager);
+		template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+		return template;
+	}
+}

--- a/src/main/java/com/soyeon/nubim/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/soyeon/nubim/security/jwt/JwtAuthenticationFilter.java
@@ -16,6 +16,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import net.minidev.json.JSONObject;
 
+import com.soyeon.nubim.common.enums.TokenValidationResult;
 import com.soyeon.nubim.security.blacklist_accesstoken.AccessTokenBlacklistService;
 
 import jakarta.servlet.FilterChain;
@@ -84,7 +85,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			log.debug("---- JWT token is empty");
 			return false;
 		}
-		if (!jwtTokenProvider.validateToken(jwt)) {
+		if ( jwtTokenProvider.validateToken(jwt) != TokenValidationResult.VALID ) {
 			log.debug("---- JWT token is invalid");
 			return false;
 		}

--- a/src/main/java/com/soyeon/nubim/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/soyeon/nubim/security/jwt/JwtTokenProvider.java
@@ -13,11 +13,14 @@ import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.soyeon.nubim.common.enums.TokenValidationResult;
+
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -79,18 +82,19 @@ public class JwtTokenProvider {
 		return refreshToken;
 	}
 
-	public boolean validateToken(String token) {
+	public TokenValidationResult validateToken(String token) {
 		try {
 			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-			return true;
+			return TokenValidationResult.VALID;
 		} catch (
-			SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+			SecurityException | MalformedJwtException | UnsupportedJwtException |
+			IllegalArgumentException | SignatureException e) {
 			logTokenValidationError(token, e.getMessage());
-			return false;
+			return TokenValidationResult.INVALID;
 		} catch (ExpiredJwtException e) {
 			String errorMessage = createJwtExpirationErrorMessage(e);
 			logTokenValidationError(token, errorMessage);
-			return false;
+			return TokenValidationResult.EXPIRED;
 		}
 	}
 

--- a/src/main/java/com/soyeon/nubim/security/refreshtoken/RefreshTokenRepository.java
+++ b/src/main/java/com/soyeon/nubim/security/refreshtoken/RefreshTokenRepository.java
@@ -16,6 +16,10 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 	@Query("DELETE FROM RefreshToken rt WHERE rt.email = :email")
 	int deleteByEmail(String email);
 
+	@Modifying
+	@Query("DELETE FROM RefreshToken rt WHERE rt.token = :refreshToken")
+	int deleteByRefreshToken(String refreshToken);
+
 	boolean existsByToken(String token);
 
 }

--- a/src/main/java/com/soyeon/nubim/security/refreshtoken/exception/ExpiredRefreshTokenException.java
+++ b/src/main/java/com/soyeon/nubim/security/refreshtoken/exception/ExpiredRefreshTokenException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.security.refreshtoken.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class ExpiredRefreshTokenException extends ResponseStatusException {
+	public ExpiredRefreshTokenException(String refreshToken) {
+		super(HttpStatus.UNAUTHORIZED, "Refresh token has expired: " + refreshToken);
+	}
+}

--- a/src/main/java/com/soyeon/nubim/security/refreshtoken/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/soyeon/nubim/security/refreshtoken/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.security.refreshtoken.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class InvalidRefreshTokenException extends ResponseStatusException {
+	public InvalidRefreshTokenException(String message) {
+		super(HttpStatus.BAD_REQUEST, "Invalid Refresh token : " + message);
+	}
+}


### PR DESCRIPTION
## 개요
NB-145
- TokenValidationResult 열거형 추가
- 커스텀 예외 클래스 추가
- JwtTokenProvider 수정
  - validateToken() 반환값 boolean에서 TokenValidationResult로 변경
- RefreshTokenRepository
  - deleteByRefreshToken() 메소드 추가
- RefreshTokenService
  - validateRefreshToken() 메소드 로직 수정
  - deleteExpiredRefreshToken() 메소드 구현
    - refresh token이 만료됐을 때 해당 토큰을 DB에서 삭제

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
