### PR TITLE
[NB-248] 사용자 약관 동의 기능 구현

### DIFF
--- a/src/main/java/com/soyeon/nubim/domain/user/User.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/User.java
@@ -79,6 +79,11 @@ public class User extends BaseEntity {
 	private Provider provider;
 
 	@Builder.Default
+	private Boolean privacyAgreement = false;
+	@Builder.Default
+	private Boolean serviceAgreement = false;
+
+	@Builder.Default
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private List<Album> albums = new ArrayList<>();
 

--- a/src/main/java/com/soyeon/nubim/domain/user/UserControllerV1.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserControllerV1.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -16,6 +17,8 @@ import org.springframework.web.multipart.MultipartFile;
 import com.soyeon.nubim.domain.user.dto.ProfileImageUpdateResponse;
 import com.soyeon.nubim.domain.user.dto.ProfileUpdateRequest;
 import com.soyeon.nubim.domain.user.dto.ProfileUpdateResponse;
+import com.soyeon.nubim.domain.user.dto.TermsAgreementUpdateRequest;
+import com.soyeon.nubim.domain.user.dto.TermsAgreementUpdateResponse;
 import com.soyeon.nubim.domain.user.dto.UserProfileResponseDto;
 import com.soyeon.nubim.security.jwt.dto.JwtTokenResponseDto;
 import com.soyeon.nubim.security.oauth.AppleOAuthLoginService;
@@ -92,5 +95,13 @@ public class UserControllerV1 {
 		String nickname) {
 		userService.validateDuplicatedNickname(nickname);
 		return ResponseEntity.ok().build();
+	}
+
+	@Operation(description = "개인정보 처리 방침, 서비스 이용 약관 동의 업데이트")
+	@PatchMapping(value = "/agreement")
+	public ResponseEntity<TermsAgreementUpdateResponse> updateTermsAgreement(TermsAgreementUpdateRequest request) {
+		TermsAgreementUpdateResponse termsAgreementUpdateResponse = userService.updateTermsAgreement(request);
+
+		return ResponseEntity.ok().body(termsAgreementUpdateResponse);
 	}
 }

--- a/src/main/java/com/soyeon/nubim/domain/user/UserRepository.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserRepository.java
@@ -48,4 +48,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@Query("UPDATE User u SET u.username = 'deleted user', u.nickname = :anonymizedNickname, u.isDeleted = true "
 		+ "WHERE u.userId = :userId")
 	int deleteAccount(Long userId, String anonymizedNickname);
+
+	@Modifying
+	@Query("UPDATE User u SET u.privacyAgreement = :privacyAgreement, u.serviceAgreement = :serviceAgreement"
+		+ " WHERE u.userId = :userId")
+	int updateTermsAgreement(Long userId, boolean privacyAgreement, boolean serviceAgreement);
 }

--- a/src/main/java/com/soyeon/nubim/domain/user/UserService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserService.java
@@ -29,6 +29,7 @@ import com.soyeon.nubim.domain.user.exception.MultipleUserAgreementUpdateExcepti
 import com.soyeon.nubim.domain.user.exception.NicknameAlreadyExistsException;
 import com.soyeon.nubim.domain.user.exception.NicknameNullOrEmptyException;
 import com.soyeon.nubim.domain.user.exception.UnsupportedProfileImageTypeException;
+import com.soyeon.nubim.domain.user.exception.UserAgreementUpdateFailException;
 import com.soyeon.nubim.domain.user.exception.UserNotFoundException;
 import com.soyeon.nubim.domain.user.exception.UsernameNullOrEmptyException;
 import com.soyeon.nubim.domain.userfollow.UserFollowRepository;
@@ -169,7 +170,7 @@ public class UserService {
 			return new TermsAgreementUpdateResponse("terms agreement update success");
 		}
 		if (updateResult == UPDATE_FAIL) {
-			return new TermsAgreementUpdateResponse("terms agreement update fail");
+			throw new UserAgreementUpdateFailException();
 		}
 		throw new MultipleUserAgreementUpdateException(updateResult);
 	}

--- a/src/main/java/com/soyeon/nubim/domain/user/UserService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserService.java
@@ -19,10 +19,13 @@ import com.soyeon.nubim.domain.postlike.PostLikeRepository;
 import com.soyeon.nubim.domain.user.dto.ProfileImageUpdateResponse;
 import com.soyeon.nubim.domain.user.dto.ProfileUpdateRequest;
 import com.soyeon.nubim.domain.user.dto.ProfileUpdateResponse;
+import com.soyeon.nubim.domain.user.dto.TermsAgreementUpdateRequest;
+import com.soyeon.nubim.domain.user.dto.TermsAgreementUpdateResponse;
 import com.soyeon.nubim.domain.user.dto.UserProfileResponseDto;
 import com.soyeon.nubim.domain.user.exception.DeletedUserSignupAttemptException;
 import com.soyeon.nubim.domain.user.exception.InvalidNicknameFormatException;
 import com.soyeon.nubim.domain.user.exception.MultipleProfileUpdateException;
+import com.soyeon.nubim.domain.user.exception.MultipleUserAgreementUpdateException;
 import com.soyeon.nubim.domain.user.exception.NicknameAlreadyExistsException;
 import com.soyeon.nubim.domain.user.exception.NicknameNullOrEmptyException;
 import com.soyeon.nubim.domain.user.exception.UnsupportedProfileImageTypeException;
@@ -38,8 +41,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class UserService {
-	private static final int PROFILE_UPDATE_SUCCESS = 1;
-	private static final int PROFILE_UPDATE_FAIL = 0;
+	private static final int UPDATE_SUCCESS = 1;
+	private static final int UPDATE_FAIL = 0;
 	private final UserRepository userRepository;
 	private final RefreshTokenService refreshTokenService;
 	private final AccessTokenBlacklistService accessTokenBlacklistService;
@@ -145,13 +148,30 @@ public class UserService {
 		int updateResult = userRepository.updateProfile(username, nickname, profileIntroduction,
 			phoneNumber, birthDate, gender, currentUserId);
 
-		if (updateResult == PROFILE_UPDATE_SUCCESS) {
+		if (updateResult == UPDATE_SUCCESS) {
 			return new ProfileUpdateResponse("profile update success");
 		}
-		if (updateResult == PROFILE_UPDATE_FAIL) {
+		if (updateResult == UPDATE_FAIL) {
 			return new ProfileUpdateResponse("profile update fail");
 		}
 		throw new MultipleProfileUpdateException();
+	}
+
+	@Transactional
+	public TermsAgreementUpdateResponse updateTermsAgreement(TermsAgreementUpdateRequest request){
+		Long userId = loggedInUserService.getCurrentUserId();
+		boolean privacyAgreement = request.isPrivacyAgreement();
+		boolean serviceAgreement = request.isServiceAgreement();
+
+		int updateResult = userRepository.updateTermsAgreement(userId, privacyAgreement, serviceAgreement);
+
+		if (updateResult == UPDATE_SUCCESS) {
+			return new TermsAgreementUpdateResponse("terms agreement update success");
+		}
+		if (updateResult == UPDATE_FAIL) {
+			return new TermsAgreementUpdateResponse("terms agreement update fail");
+		}
+		throw new MultipleUserAgreementUpdateException(updateResult);
 	}
 
 	public void checkIfUserIsDeleted(String email) {

--- a/src/main/java/com/soyeon/nubim/domain/user/dto/TermsAgreementUpdateRequest.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/dto/TermsAgreementUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.soyeon.nubim.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TermsAgreementUpdateRequest {
+	private boolean privacyAgreement;
+	private boolean serviceAgreement;
+}

--- a/src/main/java/com/soyeon/nubim/domain/user/dto/TermsAgreementUpdateResponse.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/dto/TermsAgreementUpdateResponse.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TermsAgreementUpdateResponse {
+	private String message;
+}

--- a/src/main/java/com/soyeon/nubim/domain/user/exception/MultipleUserAgreementUpdateException.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/exception/MultipleUserAgreementUpdateException.java
@@ -1,0 +1,11 @@
+package com.soyeon.nubim.domain.user.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class MultipleUserAgreementUpdateException extends ResponseStatusException {
+	public MultipleUserAgreementUpdateException(int updatedCount) {
+		super(HttpStatus.INTERNAL_SERVER_ERROR,
+			String.format("Multiple users' agreements were unexpectedly updated (%d users). Only one user's agreement should be modified at a time.", updatedCount));
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/user/exception/UserAgreementUpdateFailException.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/exception/UserAgreementUpdateFailException.java
@@ -5,6 +5,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 public class UserAgreementUpdateFailException extends ResponseStatusException {
 	public UserAgreementUpdateFailException() {
-		super(HttpStatus.NOT_FOUND, "terms agreement update fail");
+		super(HttpStatus.INTERNAL_SERVER_ERROR, "terms agreement update fail");
 	}
 }

--- a/src/main/java/com/soyeon/nubim/domain/user/exception/UserAgreementUpdateFailException.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/exception/UserAgreementUpdateFailException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class UserAgreementUpdateFailException extends ResponseStatusException {
+	public UserAgreementUpdateFailException() {
+		super(HttpStatus.NOT_FOUND, "terms agreement update fail");
+	}
+}


### PR DESCRIPTION
## 개요
NB-248
주요 변경사항:
 - User 엔티티에 약관 동의 필드 추가
  - privacyAgreement : 개인정보 처리 방침 동의
  - serviceAgreement : 서비스 이용 약관 동의

 - API 엔드 포인트 구현
  - PATCH "/v1/users/agreement"
  - 사용자별 약관 동의 상태 업데이트

구현 상세:
 - Repository : 약관 동의 상태 업데이트 쿼리 추가
 - Service : 약관 동의 처리 및 예외 처리 로직 구현
 - Controller : 약관 동의 엔드포인트 구현
 - DTO : 약관 동의 요청/응답 구조 정의
 - Exception : 다중 사용자 업데이트 방지를 위한 예외 정의
## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
