### PR TITLE
[NB-250] 사용자 약관 동의 상태 조회 기능 구현

### DIFF
--- a/src/main/java/com/soyeon/nubim/domain/user/UserControllerV1.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserControllerV1.java
@@ -17,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.soyeon.nubim.domain.user.dto.ProfileImageUpdateResponse;
 import com.soyeon.nubim.domain.user.dto.ProfileUpdateRequest;
 import com.soyeon.nubim.domain.user.dto.ProfileUpdateResponse;
+import com.soyeon.nubim.domain.user.dto.TermsAgreementStatusResponse;
 import com.soyeon.nubim.domain.user.dto.TermsAgreementUpdateRequest;
 import com.soyeon.nubim.domain.user.dto.TermsAgreementUpdateResponse;
 import com.soyeon.nubim.domain.user.dto.UserProfileResponseDto;
@@ -104,4 +105,13 @@ public class UserControllerV1 {
 
 		return ResponseEntity.ok().body(termsAgreementUpdateResponse);
 	}
+
+	@Operation(description = "사용자가 모든 약관에 동의했는지 확인")
+	@GetMapping(value = "/agreement")
+	public ResponseEntity<TermsAgreementStatusResponse> getTermsAgreement() {
+		TermsAgreementStatusResponse termsAgreementAcceptedResponse = userService.checkTermsAgreement();
+
+		return ResponseEntity.ok().body(termsAgreementAcceptedResponse);
+	}
+
 }

--- a/src/main/java/com/soyeon/nubim/domain/user/UserRepository.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserRepository.java
@@ -53,4 +53,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@Query("UPDATE User u SET u.privacyAgreement = :privacyAgreement, u.serviceAgreement = :serviceAgreement"
 		+ " WHERE u.userId = :userId")
 	int updateTermsAgreement(Long userId, boolean privacyAgreement, boolean serviceAgreement);
+
+	@Query("SELECT CASE WHEN u.privacyAgreement = true AND u.serviceAgreement = true THEN true ELSE false END"
+		+ " FROM User u WHERE u.userId = :userId ")
+	boolean isAllAgreementsAccepted(Long userId);
 }

--- a/src/main/java/com/soyeon/nubim/domain/user/UserService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserService.java
@@ -19,6 +19,7 @@ import com.soyeon.nubim.domain.postlike.PostLikeRepository;
 import com.soyeon.nubim.domain.user.dto.ProfileImageUpdateResponse;
 import com.soyeon.nubim.domain.user.dto.ProfileUpdateRequest;
 import com.soyeon.nubim.domain.user.dto.ProfileUpdateResponse;
+import com.soyeon.nubim.domain.user.dto.TermsAgreementStatusResponse;
 import com.soyeon.nubim.domain.user.dto.TermsAgreementUpdateRequest;
 import com.soyeon.nubim.domain.user.dto.TermsAgreementUpdateResponse;
 import com.soyeon.nubim.domain.user.dto.UserProfileResponseDto;
@@ -159,7 +160,7 @@ public class UserService {
 	}
 
 	@Transactional
-	public TermsAgreementUpdateResponse updateTermsAgreement(TermsAgreementUpdateRequest request){
+	public TermsAgreementUpdateResponse updateTermsAgreement(TermsAgreementUpdateRequest request) {
 		Long userId = loggedInUserService.getCurrentUserId();
 		boolean privacyAgreement = request.isPrivacyAgreement();
 		boolean serviceAgreement = request.isServiceAgreement();
@@ -173,6 +174,13 @@ public class UserService {
 			throw new UserAgreementUpdateFailException();
 		}
 		throw new MultipleUserAgreementUpdateException(updateResult);
+	}
+
+	public TermsAgreementStatusResponse checkTermsAgreement() {
+		Long currentUserId = loggedInUserService.getCurrentUserId();
+		boolean termsAgreement = userRepository.isAllAgreementsAccepted(currentUserId);
+
+		return new TermsAgreementStatusResponse(termsAgreement);
 	}
 
 	public void checkIfUserIsDeleted(String email) {

--- a/src/main/java/com/soyeon/nubim/domain/user/dto/TermsAgreementStatusResponse.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/dto/TermsAgreementStatusResponse.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TermsAgreementStatusResponse {
+	private boolean termsAgreement;
+}


### PR DESCRIPTION
## 개요
NB-250
 - 사용자가 모든 약관에 동의했는지 상태를 조회하는 API 구현

주요 변경사항:
 - API 엔드 포인트 구현
  - GET "/v1/users/agreement"
  - 사용자의 모든 약관 동의 여부 조회

구현 상세:
 - Repository : isAllAgreementsAccepted 쿼리 메소드 추가
 - Service : checkTermsAgreement 메소드 구현
 - Controller : getTermsAgreement 엔드포인트 구현
 - DTO : TermsAgreementStatusResponse 추가
## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).