### PR TITLE
[NB-249, NB-251] 사용자 간 차단 기능 구현

### DIFF
--- a/src/main/java/com/soyeon/nubim/domain/post/PostControllerV1.java
+++ b/src/main/java/com/soyeon/nubim/domain/post/PostControllerV1.java
@@ -23,6 +23,7 @@ import com.soyeon.nubim.domain.post.dto.PostResponseDto;
 import com.soyeon.nubim.domain.user.LoggedInUserService;
 import com.soyeon.nubim.domain.user.User;
 import com.soyeon.nubim.domain.user.UserService;
+import com.soyeon.nubim.domain.user_block.UserBlockService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -37,6 +38,7 @@ public class PostControllerV1 {
 	private final PostService postService;
 	private final UserService userService;
 	private final LoggedInUserService loggedInUserService;
+	private final UserBlockService userBlockService;
 
 	private static final int DEFAULT_SIMPLE_PAGE_SIZE = 10;
 	private static final int DEFAULT_MAIN_PAGE_SIZE = 5;
@@ -74,7 +76,9 @@ public class PostControllerV1 {
 		@PathVariable String nickname,
 		@RequestParam(defaultValue = "0") Long page,
 		@RequestParam(defaultValue = "desc") String sort) {
-		User user = userService.getUserByNickname(nickname);
+		User targetUser = userService.getUserByNickname(nickname);
+		User currentUser = new User(loggedInUserService.getCurrentUserId());
+		userBlockService.checkBlockRelation(currentUser, targetUser);
 
 		PageRequest pageRequest;
 		if (sort.equals("desc")) {
@@ -86,7 +90,7 @@ public class PostControllerV1 {
 		} else {
 			throw new InvalidQueryParameterException("sort");
 		}
-		return ResponseEntity.ok(postService.findAllPostsByUserOrderByCreatedAt(user, pageRequest));
+		return ResponseEntity.ok(postService.findAllPostsByUserOrderByCreatedAt(targetUser, pageRequest));
 	}
 
 	@DeleteMapping("{postId}")

--- a/src/main/java/com/soyeon/nubim/domain/user/UserService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserService.java
@@ -71,6 +71,11 @@ public class UserService {
 			.orElseThrow(() -> UserNotFoundException.forEmail(email));
 	}
 
+	public User findByNickname(String nickname) {
+		return userRepository.findByNickname(nickname)
+			.orElseThrow(()-> UserNotFoundException.forNickname(nickname));
+	}
+
 	public User saveUser(User user) {
 		return userRepository.save(user);
 	}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlock.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlock.java
@@ -1,0 +1,46 @@
+package com.soyeon.nubim.domain.user_block;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.soyeon.nubim.domain.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "user_block")
+public class UserBlock {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long userBlockId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "blocking_user_id", nullable = false)
+	private User blockingUser;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "blocked_user_id", nullable = false)
+	private User blockedUser;
+
+	@CreationTimestamp
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime blockedAt;
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockControllerV1.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockControllerV1.java
@@ -1,0 +1,51 @@
+package com.soyeon.nubim.domain.user_block;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.soyeon.nubim.domain.user_block.dto.UserBlockCreateResponse;
+import com.soyeon.nubim.domain.user_block.dto.UserBlockDeleteResponse;
+import com.soyeon.nubim.domain.user_block.dto.UserBlockReadResponse;
+import com.soyeon.nubim.domain.user_block.dto.UserBlockRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/user-block")
+@RequiredArgsConstructor
+public class UserBlockControllerV1 {
+
+	private final UserBlockService userBlockService;
+
+	@Operation(description = "사용자가 다른 사용자를 차단한다")
+	@PostMapping
+	public ResponseEntity<UserBlockCreateResponse> blockUser(@RequestBody UserBlockRequest userBlockRequest) {
+		UserBlockCreateResponse blockCreateResponse = userBlockService.blockUser(userBlockRequest);
+
+		return ResponseEntity.ok().body(blockCreateResponse);
+	}
+
+	@Operation(description = "사용자가 차단한 사용자들의 리스트를 검색한다")
+	@GetMapping
+	public ResponseEntity<List<UserBlockReadResponse>> getBlockedUsers() {
+		List<UserBlockReadResponse> userBlockReadResponses = userBlockService.getBlockedUsers();
+
+		return ResponseEntity.ok().body(userBlockReadResponses);
+	}
+
+	@Operation(description = "사용자가 다른 사용자에 대한 차단을 해제한다")
+	@DeleteMapping
+	public ResponseEntity<UserBlockDeleteResponse> unblockUser(@RequestBody UserBlockRequest userBlockRequest) {
+		UserBlockDeleteResponse blockDeleteResponse = userBlockService.unblockUser(userBlockRequest);
+
+		return ResponseEntity.ok().body(blockDeleteResponse);
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockMapper.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockMapper.java
@@ -1,0 +1,54 @@
+package com.soyeon.nubim.domain.user_block;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.soyeon.nubim.domain.user.User;
+import com.soyeon.nubim.domain.user.UserMapper;
+import com.soyeon.nubim.domain.user.dto.UserSimpleResponseDto;
+import com.soyeon.nubim.domain.user_block.dto.UserBlockCreateResponse;
+import com.soyeon.nubim.domain.user_block.dto.UserBlockReadResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserBlockMapper {
+
+	private final UserMapper userMapper;
+
+	public UserBlock toEntity(User blockingUser, User blockedUser) {
+		return UserBlock.builder()
+			.blockingUser(blockingUser)
+			.blockedUser(blockedUser)
+			.build();
+	}
+
+	public UserBlockCreateResponse toUserBlockCreateResponse(UserBlock userBlock) {
+		UserSimpleResponseDto blockedUser = userMapper.toUserSimpleResponseDto(userBlock.getBlockedUser());
+
+		return UserBlockCreateResponse.builder()
+			.blockedUser(blockedUser)
+			.blockedAt(userBlock.getBlockedAt())
+			.build();
+	}
+
+	public UserBlockReadResponse toUserBlockReadResponse(UserBlock userBlock) {
+		UserSimpleResponseDto blockedUser = userMapper.toUserSimpleResponseDto(userBlock.getBlockedUser());
+
+		return UserBlockReadResponse.builder()
+			.blockedUser(blockedUser)
+			.blockedAt(userBlock.getBlockedAt())
+			.build();
+	}
+
+	public List<UserBlockReadResponse> toUserBlockReadResponses(List<UserBlock> userBlocks) {
+		List<UserBlockReadResponse> userBlockReadResponses = new ArrayList<>(userBlocks.size());
+		for (UserBlock userBlock : userBlocks) {
+			userBlockReadResponses.add(toUserBlockReadResponse(userBlock));
+		}
+		return userBlockReadResponses;
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockRepository.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockRepository.java
@@ -1,0 +1,25 @@
+package com.soyeon.nubim.domain.user_block;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.soyeon.nubim.domain.user.User;
+
+@Repository
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+
+	@Query("SELECT EXISTS( SELECT 1 FROM UserBlock ub"
+		+ " WHERE ub.blockingUser = :blockingUser AND ub.blockedUser = :blockedUser)")
+	boolean existsByBlockingUserAndBlockedUser(User blockingUser, User blockedUser);
+
+	@Query("SELECT ub FROM UserBlock ub WHERE ub.blockingUser = :blockingUser")
+	List<UserBlock> findBlockedUsersByBlockingUser(User blockingUser);
+
+	@Modifying
+	@Query("DELETE FROM UserBlock ub WHERE ub.blockingUser = :blockingUser AND ub.blockedUser = :blockedUser")
+	int deleteByBlockingUserAndBlockedUser(User blockingUser, User blockedUser);
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockRepository.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockRepository.java
@@ -16,6 +16,11 @@ public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
 		+ " WHERE ub.blockingUser = :blockingUser AND ub.blockedUser = :blockedUser)")
 	boolean existsByBlockingUserAndBlockedUser(User blockingUser, User blockedUser);
 
+	@Query("SELECT EXISTS( SELECT 1 FROM UserBlock ub WHERE "
+		+ "(ub.blockingUser = :user1 AND ub.blockedUser = :user2 ) OR "
+		+ "(ub.blockingUser = :user2 AND ub.blockedUser = :user1 ))")
+	boolean existsBlockRelationBetweenUser(User user1, User user2);
+
 	@Query("SELECT ub FROM UserBlock ub WHERE ub.blockingUser = :blockingUser")
 	List<UserBlock> findBlockedUsersByBlockingUser(User blockingUser);
 

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
@@ -1,0 +1,75 @@
+package com.soyeon.nubim.domain.user_block;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.soyeon.nubim.domain.user.LoggedInUserService;
+import com.soyeon.nubim.domain.user.User;
+import com.soyeon.nubim.domain.user.UserService;
+import com.soyeon.nubim.domain.user_block.dto.UserBlockCreateResponse;
+import com.soyeon.nubim.domain.user_block.dto.UserBlockDeleteResponse;
+import com.soyeon.nubim.domain.user_block.dto.UserBlockReadResponse;
+import com.soyeon.nubim.domain.user_block.dto.UserBlockRequest;
+import com.soyeon.nubim.domain.user_block.exception.AlreadyBlockedException;
+import com.soyeon.nubim.domain.user_block.exception.MultipleUserBlockDeletedException;
+import com.soyeon.nubim.domain.user_block.exception.UserBlockDeleteFailException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserBlockService {
+
+	private static final int DELETE_SUCCESS = 1;
+	private static final int DELETE_FAIL = 0;
+	private final LoggedInUserService loggedInUserService;
+	private final UserService userService;
+	private final UserBlockRepository userBlockRepository;
+	private final UserBlockMapper userBlockMapper;
+
+	public UserBlockCreateResponse blockUser(UserBlockRequest userBlockRequest) {
+		Long currentUserId = loggedInUserService.getCurrentUserId();
+		User blockingUser = new User(currentUserId);
+		User blockedUser = userService.findUserByIdOrThrow(userBlockRequest.getBlockedUserId());
+
+		validateUserBlockNotExists(blockingUser, blockedUser);
+
+		UserBlock userBlock = userBlockMapper.toEntity(blockingUser, blockedUser);
+		UserBlock savedUserBlock = userBlockRepository.save(userBlock);
+
+		return userBlockMapper.toUserBlockCreateResponse(savedUserBlock);
+	}
+
+	public List<UserBlockReadResponse> getBlockedUsers() {
+		Long currentUserId = loggedInUserService.getCurrentUserId();
+		User blockingUser = new User(currentUserId);
+
+		List<UserBlock> blockedUsers = userBlockRepository.findBlockedUsersByBlockingUser(blockingUser);
+		return userBlockMapper.toUserBlockReadResponses(blockedUsers);
+	}
+
+	@Transactional
+	public UserBlockDeleteResponse unblockUser(UserBlockRequest userBlockRequest) {
+		Long currentUserId = loggedInUserService.getCurrentUserId();
+		User blockingUser = new User(currentUserId);
+		User blockedUser = userService.findUserByIdOrThrow(userBlockRequest.getBlockedUserId());
+
+		int deleteResult = userBlockRepository.deleteByBlockingUserAndBlockedUser(blockingUser, blockedUser);
+
+		if (deleteResult == DELETE_SUCCESS) {
+			return new UserBlockDeleteResponse("unblock success");
+		}
+		if (deleteResult == DELETE_FAIL) {
+			throw new UserBlockDeleteFailException();
+		}
+		throw new MultipleUserBlockDeletedException();
+	}
+
+	private void validateUserBlockNotExists(User blockingUser, User blockedUser) {
+		if (userBlockRepository.existsByBlockingUserAndBlockedUser(blockingUser, blockedUser)) {
+			throw new AlreadyBlockedException();
+		}
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
@@ -15,6 +15,7 @@ import com.soyeon.nubim.domain.user_block.dto.UserBlockRequest;
 import com.soyeon.nubim.domain.user_block.exception.AlreadyBlockedException;
 import com.soyeon.nubim.domain.user_block.exception.BlockedUserAccessDeniedException;
 import com.soyeon.nubim.domain.user_block.exception.MultipleUserBlockDeletedException;
+import com.soyeon.nubim.domain.user_block.exception.SelfBlockException;
 import com.soyeon.nubim.domain.user_block.exception.UserBlockDeleteFailException;
 
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,7 @@ public class UserBlockService {
 		User blockingUser = new User(currentUserId);
 		User blockedUser = userService.findByNickname(userBlockRequest.getBlockedUserNickname());
 
+		checkSelfBlock(blockingUser, blockedUser);
 		validateUserBlockNotExists(blockingUser, blockedUser);
 
 		UserBlock userBlock = userBlockMapper.toEntity(blockingUser, blockedUser);
@@ -71,6 +73,12 @@ public class UserBlockService {
 	public void checkBlockRelation(User currentUser, User targetUser) {
 		if (userBlockRepository.existsBlockRelationBetweenUser(currentUser, targetUser)) {
 			throw new BlockedUserAccessDeniedException();
+		}
+	}
+
+	private void checkSelfBlock(User blockingUser, User blockedUser) {
+		if (blockingUser.getUserId().equals(blockedUser.getUserId())) {
+			throw new SelfBlockException();
 		}
 	}
 

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
@@ -32,7 +32,7 @@ public class UserBlockService {
 	public UserBlockCreateResponse blockUser(UserBlockRequest userBlockRequest) {
 		Long currentUserId = loggedInUserService.getCurrentUserId();
 		User blockingUser = new User(currentUserId);
-		User blockedUser = userService.findUserByIdOrThrow(userBlockRequest.getBlockedUserId());
+		User blockedUser = userService.findByNickname(userBlockRequest.getBlockedUserNickname());
 
 		validateUserBlockNotExists(blockingUser, blockedUser);
 
@@ -54,7 +54,7 @@ public class UserBlockService {
 	public UserBlockDeleteResponse unblockUser(UserBlockRequest userBlockRequest) {
 		Long currentUserId = loggedInUserService.getCurrentUserId();
 		User blockingUser = new User(currentUserId);
-		User blockedUser = userService.findUserByIdOrThrow(userBlockRequest.getBlockedUserId());
+		User blockedUser = userService.findByNickname(userBlockRequest.getBlockedUserNickname());
 
 		int deleteResult = userBlockRepository.deleteByBlockingUserAndBlockedUser(blockingUser, blockedUser);
 

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
@@ -13,6 +13,7 @@ import com.soyeon.nubim.domain.user_block.dto.UserBlockDeleteResponse;
 import com.soyeon.nubim.domain.user_block.dto.UserBlockReadResponse;
 import com.soyeon.nubim.domain.user_block.dto.UserBlockRequest;
 import com.soyeon.nubim.domain.user_block.exception.AlreadyBlockedException;
+import com.soyeon.nubim.domain.user_block.exception.BlockedUserAccessDeniedException;
 import com.soyeon.nubim.domain.user_block.exception.MultipleUserBlockDeletedException;
 import com.soyeon.nubim.domain.user_block.exception.UserBlockDeleteFailException;
 
@@ -65,6 +66,12 @@ public class UserBlockService {
 			throw new UserBlockDeleteFailException();
 		}
 		throw new MultipleUserBlockDeletedException();
+	}
+
+	public void checkBlockRelation(User currentUser, User targetUser) {
+		if (userBlockRepository.existsBlockRelationBetweenUser(currentUser, targetUser)) {
+			throw new BlockedUserAccessDeniedException();
+		}
 	}
 
 	private void validateUserBlockNotExists(User blockingUser, User blockedUser) {

--- a/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockCreateResponse.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockCreateResponse.java
@@ -1,0 +1,15 @@
+package com.soyeon.nubim.domain.user_block.dto;
+
+import java.time.LocalDateTime;
+
+import com.soyeon.nubim.domain.user.dto.UserSimpleResponseDto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserBlockCreateResponse {
+	private UserSimpleResponseDto blockedUser;
+	private LocalDateTime blockedAt;
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockDeleteResponse.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockDeleteResponse.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user_block.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserBlockDeleteResponse {
+	private String message;
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockReadResponse.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockReadResponse.java
@@ -1,0 +1,15 @@
+package com.soyeon.nubim.domain.user_block.dto;
+
+import java.time.LocalDateTime;
+
+import com.soyeon.nubim.domain.user.dto.UserSimpleResponseDto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserBlockReadResponse {
+	private UserSimpleResponseDto blockedUser;
+	private LocalDateTime blockedAt;
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockRequest.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockRequest.java
@@ -6,5 +6,5 @@ import lombok.Setter;
 @Getter
 @Setter
 public class UserBlockRequest {
-	private Long blockedUserId;
+	private String blockedUserNickname;
 }

--- a/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockRequest.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/dto/UserBlockRequest.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user_block.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserBlockRequest {
+	private Long blockedUserId;
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/exception/AlreadyBlockedException.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/exception/AlreadyBlockedException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user_block.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class AlreadyBlockedException extends ResponseStatusException {
+	public AlreadyBlockedException() {
+		super(HttpStatus.CONFLICT, "Already Blocked User");
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/exception/BlockedUserAccessDeniedException.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/exception/BlockedUserAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user_block.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class BlockedUserAccessDeniedException extends ResponseStatusException {
+	public BlockedUserAccessDeniedException() {
+		super(HttpStatus.FORBIDDEN, "blocked user access denied");
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/exception/MultipleUserBlockDeletedException.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/exception/MultipleUserBlockDeletedException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user_block.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class MultipleUserBlockDeletedException extends ResponseStatusException {
+	public MultipleUserBlockDeletedException() {
+		super(HttpStatus.INTERNAL_SERVER_ERROR, "Multiple UserBlock deleted");
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/exception/SelfBlockException.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/exception/SelfBlockException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user_block.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class SelfBlockException extends ResponseStatusException {
+	public SelfBlockException() {
+		super(HttpStatus.BAD_REQUEST, "cannot block yourself");
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/exception/UserBlockDeleteFailException.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/exception/UserBlockDeleteFailException.java
@@ -1,0 +1,10 @@
+package com.soyeon.nubim.domain.user_block.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class UserBlockDeleteFailException extends ResponseStatusException {
+	public UserBlockDeleteFailException() {
+		super(HttpStatus.BAD_REQUEST, "UserBlock does not exist");
+	}
+}


### PR DESCRIPTION
## 개요
NB-249
- 사용자 간 차단 관계를 생성/조회/해제 기능 구현
  - blockingUser : 차단을 수행한 사용자
  - blockedUser : 차단된 사용자
- 사용자의 닉네임을 기반으로 차단함.

NB-251
- 차단된 사용자의 게시글 조회 제한 구현
  - 닉네임 기반으로 게시글 조회 시 상호 차단 관계를 확인한다.
  - 내가 차단했거나, 나를 차단한 경우 게시글 조회를 제한한다.

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).