### PR TITLE
[NB-252,NB-253,NB-254] 사용자 간 차단 기능 확장

### DIFF
--- a/src/main/java/com/soyeon/nubim/domain/post/PostControllerV1.java
+++ b/src/main/java/com/soyeon/nubim/domain/post/PostControllerV1.java
@@ -23,7 +23,7 @@ import com.soyeon.nubim.domain.post.dto.PostResponseDto;
 import com.soyeon.nubim.domain.user.LoggedInUserService;
 import com.soyeon.nubim.domain.user.User;
 import com.soyeon.nubim.domain.user.UserService;
-import com.soyeon.nubim.domain.user_block.UserBlockService;
+import com.soyeon.nubim.domain.user_block.UserBlockValidator;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -38,7 +38,7 @@ public class PostControllerV1 {
 	private final PostService postService;
 	private final UserService userService;
 	private final LoggedInUserService loggedInUserService;
-	private final UserBlockService userBlockService;
+	private final UserBlockValidator userBlockValidator;
 
 	private static final int DEFAULT_SIMPLE_PAGE_SIZE = 10;
 	private static final int DEFAULT_MAIN_PAGE_SIZE = 5;
@@ -78,7 +78,7 @@ public class PostControllerV1 {
 		@RequestParam(defaultValue = "desc") String sort) {
 		User targetUser = userService.getUserByNickname(nickname);
 		User currentUser = new User(loggedInUserService.getCurrentUserId());
-		userBlockService.checkBlockRelation(currentUser, targetUser);
+		userBlockValidator.checkBlockRelation(currentUser, targetUser);
 
 		PageRequest pageRequest;
 		if (sort.equals("desc")) {

--- a/src/main/java/com/soyeon/nubim/domain/post/PostRepository.java
+++ b/src/main/java/com/soyeon/nubim/domain/post/PostRepository.java
@@ -26,7 +26,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	@Query(value = "SELECT SETSEED(:seed)", nativeQuery = true)
 	void setSeed(Float seed);
 
-	@Query(value = "SELECT p FROM Post p WHERE p.user != :user ORDER BY function('RANDOM')")
+	@Query(value = "SELECT p FROM Post p WHERE p.user != :user "
+		+ "AND NOT EXISTS (SELECT ub FROM UserBlock ub WHERE ub.blockingUser = :user AND ub.blockedUser = p.user) "
+		+ "AND NOT EXISTS (SELECT ub FROM UserBlock ub WHERE ub.blockingUser = p.user AND ub.blockedUser = :user) "
+		+ "ORDER BY function('RANDOM')")
 	Page<Post> findRandomPostsExceptMine(Pageable pageable, User user);
 
 	Page<Post> findByPostTitleContainingOrPostContentContaining(

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockService.java
@@ -17,6 +17,7 @@ import com.soyeon.nubim.domain.user_block.exception.BlockedUserAccessDeniedExcep
 import com.soyeon.nubim.domain.user_block.exception.MultipleUserBlockDeletedException;
 import com.soyeon.nubim.domain.user_block.exception.SelfBlockException;
 import com.soyeon.nubim.domain.user_block.exception.UserBlockDeleteFailException;
+import com.soyeon.nubim.domain.userfollow.UserFollowService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,7 +31,9 @@ public class UserBlockService {
 	private final UserService userService;
 	private final UserBlockRepository userBlockRepository;
 	private final UserBlockMapper userBlockMapper;
+	private final UserFollowService userFollowService;
 
+	@Transactional
 	public UserBlockCreateResponse blockUser(UserBlockRequest userBlockRequest) {
 		Long currentUserId = loggedInUserService.getCurrentUserId();
 		User blockingUser = new User(currentUserId);
@@ -41,6 +44,8 @@ public class UserBlockService {
 
 		UserBlock userBlock = userBlockMapper.toEntity(blockingUser, blockedUser);
 		UserBlock savedUserBlock = userBlockRepository.save(userBlock);
+
+		userFollowService.deleteFollowBetweenUsers(blockingUser, blockedUser);
 
 		return userBlockMapper.toUserBlockCreateResponse(savedUserBlock);
 	}

--- a/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockValidator.java
+++ b/src/main/java/com/soyeon/nubim/domain/user_block/UserBlockValidator.java
@@ -1,0 +1,34 @@
+package com.soyeon.nubim.domain.user_block;
+
+import org.springframework.stereotype.Service;
+
+import com.soyeon.nubim.domain.user.User;
+import com.soyeon.nubim.domain.user_block.exception.AlreadyBlockedException;
+import com.soyeon.nubim.domain.user_block.exception.BlockedUserAccessDeniedException;
+import com.soyeon.nubim.domain.user_block.exception.SelfBlockException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserBlockValidator {
+	private final UserBlockRepository userBlockRepository;
+
+	public void checkBlockRelation(User currentUser, User targetUser) {
+		if (userBlockRepository.existsBlockRelationBetweenUser(currentUser, targetUser)) {
+			throw new BlockedUserAccessDeniedException();
+		}
+	}
+
+	protected void checkSelfBlock(User blockingUser, User blockedUser) {
+		if (blockingUser.getUserId().equals(blockedUser.getUserId())) {
+			throw new SelfBlockException();
+		}
+	}
+
+	protected void validateUserBlockNotExists(User blockingUser, User blockedUser) {
+		if (userBlockRepository.existsByBlockingUserAndBlockedUser(blockingUser, blockedUser)) {
+			throw new AlreadyBlockedException();
+		}
+	}
+}

--- a/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowRepository.java
+++ b/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowRepository.java
@@ -32,7 +32,8 @@ public interface UserFollowRepository extends JpaRepository<UserFollow, Long> {
 	int deleteFolloweeByUserId(Long userId);
 
 	@Modifying
-	@Query("UPDATE UserFollow uf SET uf.isDeleted = true " +
-		"WHERE uf.follower.userId = :userId OR uf.followee.userId = :userId")
-	int deleteFollowByUserId(Long userId);
+	@Query("UPDATE UserFollow uf SET uf.isDeleted = true "
+		+ "WHERE (uf.follower.userId = :blockingUserId AND uf.followee.userId = :blockedUserId) "
+		+ "OR (uf.follower.userId = :blockedUserId AND uf.followee.userId = :blockingUserId)")
+	int deleteFollowByUserId(Long blockingUserId, Long blockedUserId);
 }

--- a/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowRepository.java
+++ b/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowRepository.java
@@ -30,4 +30,9 @@ public interface UserFollowRepository extends JpaRepository<UserFollow, Long> {
 	@Modifying
 	@Query("UPDATE UserFollow uf SET uf.isDeleted = true WHERE uf.followee.userId = :userId")
 	int deleteFolloweeByUserId(Long userId);
+
+	@Modifying
+	@Query("UPDATE UserFollow uf SET uf.isDeleted = true " +
+		"WHERE uf.follower.userId = :userId OR uf.followee.userId = :userId")
+	int deleteFollowByUserId(Long userId);
 }

--- a/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowService.java
+++ b/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowService.java
@@ -76,6 +76,14 @@ public class UserFollowService {
 			.build();
 	}
 
+	public void deleteFollowBetweenUsers(User blockingUser, User blockedUser) {
+		Long blockingUserId = blockingUser.getUserId();
+		Long blockedUserId = blockedUser.getUserId();
+
+		userFollowRepository.deleteFollowByUserId(blockingUserId);
+		userFollowRepository.deleteFollowByUserId(blockedUserId);
+	}
+
 	public Page<UserSimpleResponseDto> getFollowers(Pageable pageable) {
 		User followee = loggedInUserService.getCurrentUser();
 

--- a/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowService.java
+++ b/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowService.java
@@ -83,8 +83,7 @@ public class UserFollowService {
 		Long blockingUserId = blockingUser.getUserId();
 		Long blockedUserId = blockedUser.getUserId();
 
-		userFollowRepository.deleteFollowByUserId(blockingUserId);
-		userFollowRepository.deleteFollowByUserId(blockedUserId);
+		userFollowRepository.deleteFollowByUserId(blockingUserId, blockedUserId);
 	}
 
 	public Page<UserSimpleResponseDto> getFollowers(Pageable pageable) {

--- a/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowService.java
+++ b/src/main/java/com/soyeon/nubim/domain/userfollow/UserFollowService.java
@@ -9,6 +9,7 @@ import com.soyeon.nubim.domain.user.User;
 import com.soyeon.nubim.domain.user.UserMapper;
 import com.soyeon.nubim.domain.user.UserService;
 import com.soyeon.nubim.domain.user.dto.UserSimpleResponseDto;
+import com.soyeon.nubim.domain.user_block.UserBlockValidator;
 import com.soyeon.nubim.domain.userfollow.dto.FollowUserResponseDto;
 import com.soyeon.nubim.domain.userfollow.exception.FollowingStatusException;
 
@@ -21,6 +22,7 @@ public class UserFollowService {
 	private final UserService userService;
 	private final UserMapper userMapper;
 	private final LoggedInUserService loggedInUserService;
+	private final UserBlockValidator userBlockValidator;
 
 	public FollowUserResponseDto createFollow(String nickname) {
 		User followee = userService.getUserByNickname(nickname);
@@ -33,6 +35,7 @@ public class UserFollowService {
 		if (this.isFollowing(follower, followee)) {
 			throw FollowingStatusException.alreadyFollowing(nickname);
 		}
+		userBlockValidator.checkBlockRelation(follower, followee);
 
 		UserFollow userFollow = UserFollow.builder()
 			.follower(follower)


### PR DESCRIPTION
## 개요
NB-252
- 차단 시 팔로우 관계 삭제 기능 추가
- 사용자와 차단된 사용자와의 팔로우 관계를 삭제한다.

NB-253
- 차단한 사용자간 팔로우 제한 기능 추가
- 사용자 차단 시 차단된 사용자 간 팔로우가 제한된다.

NB-254
- 차단 관계에 있는 사용자의 게시글 메인 페이지 노출 제한 기능 구현
- 랜덤 게시글 조회 쿼리를 수정하여 차단 관계이 있는 사용자의 게시글이 메인 페이지에서 제외되도록 수정

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).