### PR TITLE
[NB-193] 프로필 이미지 저장 형식을 CDN URL로 변경

### DIFF
--- a/src/main/java/com/soyeon/nubim/common/util/aws/S3ImageUploader.java
+++ b/src/main/java/com/soyeon/nubim/common/util/aws/S3ImageUploader.java
@@ -41,7 +41,7 @@ public class S3ImageUploader {
 	}
 
 	public String getFullS3Path(String uploadPath) {
-		return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, uploadPath);
+		return String.format("https://%s.s3.%s.amazonaws.com%s", bucketName, region, uploadPath);
 	}
 
 }

--- a/src/main/java/com/soyeon/nubim/domain/user/UserService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.soyeon.nubim.common.enums.Gender;
+import com.soyeon.nubim.common.util.aws.S3AndCdnUrlConverter;
 import com.soyeon.nubim.common.util.aws.S3ImageUploader;
 import com.soyeon.nubim.domain.comment.CommentRepository;
 import com.soyeon.nubim.domain.post.PostRepository;
@@ -62,6 +63,7 @@ public class UserService {
 	private final PostLikeRepository postLikeRepository;
 	private final PostRepository postRepository;
 	private final UserFollowRepository userFollowRepository;
+	private final S3AndCdnUrlConverter s3AndCdnUrlConverter;
 
 	public UserProfileResponseDto getCurrentUserProfile() {
 		User currentUser = loggedInUserService.getCurrentUser();
@@ -134,7 +136,7 @@ public class UserService {
 	public ProfileImageUpdateResponse updateProfileImage(MultipartFile profileImage) {
 		validateProfileImageContentType(profileImage.getContentType());
 
-		String uploadPath = "users/" + loggedInUserService.getCurrentUserId() + "/profile/" + UUID.randomUUID()
+		String uploadPath = "/users/" + loggedInUserService.getCurrentUserId() + "/profile/" + UUID.randomUUID()
 			.toString()
 			.substring(0, 4);
 		String uploadResponse = s3ImageUploader.uploadImage(uploadPath, profileImage);
@@ -142,7 +144,8 @@ public class UserService {
 		if (uploadResponse.contains("fail")) {
 			return new ProfileImageUpdateResponse("profile image update fail", null);
 		}
-		userRepository.updateProfileImage(uploadResponse, loggedInUserService.getCurrentUserId());
+		String cdnUrl = s3AndCdnUrlConverter.convertPathToCdnUrl(uploadPath);
+		userRepository.updateProfileImage(cdnUrl, loggedInUserService.getCurrentUserId());
 		return new ProfileImageUpdateResponse("profile image update success", uploadResponse);
 	}
 


### PR DESCRIPTION
## 개요
NB-193
-  프로필 이미지 업로드 후 DB에 저장되는 URL을 S3 URL에서 CDN URL로 변경함.
- UserService
  - S3AndCdnUrlConverter에서 사용될 수 있도록 uploadPath 시작에 "/" 추가
  - 프로필 이미지 업로드 성공 시 CDN URL로 변경 로직 추가
- S3ImageUploader
  - 변경된 uploadPath에 맞게 로직 수정

## PR 유형
어떤 변경 사항이 있나요?
- [x] 버그 수정
- [x] 코드 리팩토링
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
