### PR TITLE
[NB-256] 다른 사용자 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/soyeon/nubim/domain/user/UserControllerV1.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserControllerV1.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -45,6 +46,14 @@ public class UserControllerV1 {
 
 		return ResponseEntity.ok()
 			.body(currentUserProfile);
+	}
+
+	@GetMapping("/{nickname}")
+	public ResponseEntity<UserProfileResponseDto> getUserProfile(@PathVariable String nickname) {
+		UserProfileResponseDto userProfile = userService.getUserProfile(nickname);
+
+		return ResponseEntity.ok()
+			.body(userProfile);
 	}
 
 	@GetMapping("/login-google")

--- a/src/main/java/com/soyeon/nubim/domain/user/UserMapper.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserMapper.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import com.soyeon.nubim.domain.album.Album;
 import com.soyeon.nubim.domain.album.dto.AlbumReadResponseDto;
 import com.soyeon.nubim.domain.album.mapper.AlbumMapper;
 import com.soyeon.nubim.domain.post.Post;
@@ -49,9 +48,13 @@ public class UserMapper {
 			.build();
 	}
 
-	public UserProfileResponseDto toUserProfileResponseDto(User user) {
-		List<Album> albums = user.getAlbums();
-		List<AlbumReadResponseDto> albumReadResponseDtos = albumMapper.toAlbumReadResponseDtoList(albums);
+	public UserProfileResponseDto toUserProfileResponseDto(User user, boolean isCurrentUser) {
+		List<AlbumReadResponseDto> albumReadResponseDtos;
+		if (isCurrentUser) {
+			albumReadResponseDtos = albumMapper.toAlbumReadResponseDtoList(user.getAlbums());
+		} else {
+			albumReadResponseDtos = null;
+		}
 
 		List<Post> posts = user.getPosts();
 		List<PostDetailResponseDto> postDetailResponseDtos = postMapper.toPostDetailResponseDtos(posts);

--- a/src/main/java/com/soyeon/nubim/domain/user/UserService.java
+++ b/src/main/java/com/soyeon/nubim/domain/user/UserService.java
@@ -68,7 +68,17 @@ public class UserService {
 	public UserProfileResponseDto getCurrentUserProfile() {
 		User currentUser = loggedInUserService.getCurrentUser();
 
-		return userMapper.toUserProfileResponseDto(currentUser);
+		return userMapper.toUserProfileResponseDto(currentUser, true);
+	}
+
+	public UserProfileResponseDto getUserProfile(String nickname) {
+		User user = findByNickname(nickname);
+		Long currentUserId = loggedInUserService.getCurrentUserId();
+
+		if (user.getUserId().equals(currentUserId)) {
+			return userMapper.toUserProfileResponseDto(user, true);
+		}
+		return userMapper.toUserProfileResponseDto(user, false);
 	}
 
 	public Optional<User> findById(Long userId) {
@@ -82,7 +92,7 @@ public class UserService {
 
 	public User findByNickname(String nickname) {
 		return userRepository.findByNickname(nickname)
-			.orElseThrow(()-> UserNotFoundException.forNickname(nickname));
+			.orElseThrow(() -> UserNotFoundException.forNickname(nickname));
 	}
 
 	public User saveUser(User user) {
@@ -144,7 +154,7 @@ public class UserService {
 		if (uploadResponse.contains("fail")) {
 			return new ProfileImageUpdateResponse("profile image update fail", null);
 		}
-		String cdnUrl = s3AndCdnUrlConverter.convertPathToCdnUrl("/"+uploadPath);
+		String cdnUrl = s3AndCdnUrlConverter.convertPathToCdnUrl("/" + uploadPath);
 		userRepository.updateProfileImage(cdnUrl, loggedInUserService.getCurrentUserId());
 		return new ProfileImageUpdateResponse("profile image update success", uploadResponse);
 	}


### PR DESCRIPTION
## 개요
NB-256
- 다른 사용자의 프로필을 닉네임 기반으로 조회하는 API 구현
- 프로필 조회 시 자신/타인 구분하여 앨범 정보 제공 여부를 다르게 처리
## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
